### PR TITLE
[FEAT] <영찬> eslint config: endofLine auto rules added

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,5 +21,6 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    'prettier/prettier': ['error', { endOfLine: 'auto' }],
   },
 };


### PR DESCRIPTION
맥과 윈도우의 OS별 줄바꿈 방식의 차이로 인한 eslint rules 추가